### PR TITLE
feat: two-way SMS via Telegram control bot

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/BootReceiver.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/BootReceiver.kt
@@ -10,22 +10,26 @@ import androidx.core.content.ContextCompat
 
 /**
  * Listens for system boot completion and app updates.
- * Restarts ForegroundService if it was enabled.
+ * Restarts ForegroundService if forwarding was enabled or control bot is configured.
  */
 class BootReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         val action = intent.action ?: return
 
-        if (action == Intent.ACTION_BOOT_COMPLETED || 
+        if (action == Intent.ACTION_BOOT_COMPLETED ||
             action == Intent.ACTION_MY_PACKAGE_REPLACED) {
 
             val dbManager = DbManager.getInstance(context)
-            if (!dbManager.getBoolSetting("isRunning")) return
-            if (!dbManager.getBoolSetting("enableForeground")) return
+            val needsForeground =
+                (dbManager.getBoolSetting("isRunning") && dbManager.getBoolSetting("enableForeground")) ||
+                dbManager.getBoolSetting("controlBotEnabled")
 
-            val serviceIntent = Intent(context, ForegroundService::class.java)
-            ContextCompat.startForegroundService(context, serviceIntent)
+            if (!needsForeground) return
+
+            ContextCompat.startForegroundService(
+                context, Intent(context, ForegroundService::class.java)
+            )
         }
     }
 }

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/DbManager.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/DbManager.kt
@@ -89,6 +89,17 @@ class DbManager private constructor(private val context: Context) {
         return getSetting(key)?.let { it == "1" || it.equals("true", ignoreCase = true) } ?: defaultValue
     }
 
+    // Write a setting from native side (used for polling offset persistence)
+    fun saveSetting(key: String, value: String) {
+        withDatabase { db ->
+            val values = android.content.ContentValues().apply {
+                put("key", key)
+                put("value", value)
+            }
+            db.insertWithOnConflict("app_settings", null, values, android.database.sqlite.SQLiteDatabase.CONFLICT_REPLACE)
+        }
+    }
+
     // ================================================================================
     // FORWARDING_RULES
     // ================================================================================

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/ForegroundService.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/ForegroundService.kt
@@ -10,24 +10,43 @@ import android.app.Service
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 /**
  * Runs permanently in the background and provides a notification.
+ * Also manages the TelegramPoller coroutine for two-way SMS.
  */
 class ForegroundService : Service() {
 
     companion object {
+        private const val TAG = "ForegroundService"
         private const val CHANNEL_ID = "sms_telebot_foreground"
         private const val NOTIFICATION_ID = 1002
+        const val ACTION_RELOAD_CONTROL_BOT = "com.teslor.sms_telebot.RELOAD_CONTROL_BOT"
     }
+
+    private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var pollerJob: Job? = null
 
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
+        startPollerIfEnabled()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_RELOAD_CONTROL_BOT) {
+            Log.d(TAG, "Reloading control bot config")
+            restartPoller()
+            return START_STICKY
+        }
+
         val launchIntent = Intent(this, MainActivity::class.java).apply {
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
         }
@@ -48,16 +67,40 @@ class ForegroundService : Service() {
             .setContentIntent(contentIntent)
             .build()
 
-        // Repeated starts are safe: Android updates the same foreground notification
         startForeground(NOTIFICATION_ID, notification)
-
-        // Restart service after process termination if needed
         return START_STICKY
+    }
+
+    override fun onDestroy() {
+        pollerJob?.cancel()
+        serviceScope.coroutineContext[Job]?.cancel()
+        super.onDestroy()
+        Log.d(TAG, "Service destroyed, poller cancelled")
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
-    // Create a notification channel for Android 8.0+
+    private fun startPollerIfEnabled() {
+        val dbManager = DbManager.getInstance(this)
+        if (!dbManager.getBoolSetting("controlBotEnabled")) return
+
+        pollerJob?.cancel()
+        pollerJob = serviceScope.launch {
+            val poller = TelegramPoller(
+                applicationContext,
+                dbManager,
+                SecureStorageManager.getInstance(applicationContext)
+            )
+            poller.run()
+        }
+        Log.i(TAG, "TelegramPoller started")
+    }
+
+    private fun restartPoller() {
+        pollerJob?.cancel()
+        startPollerIfEnabled()
+    }
+
     private fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
 

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/ForegroundService.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/ForegroundService.kt
@@ -68,6 +68,7 @@ class ForegroundService : Service() {
             .build()
 
         startForeground(NOTIFICATION_ID, notification)
+        startPollerIfEnabled()
         return START_STICKY
     }
 
@@ -83,6 +84,9 @@ class ForegroundService : Service() {
     private fun startPollerIfEnabled() {
         val dbManager = DbManager.getInstance(this)
         if (!dbManager.getBoolSetting("controlBotEnabled")) return
+
+        val tokenResult = SecureStorageManager.getInstance(this).readSecret("control_bot")
+        if (!tokenResult.isSuccess || tokenResult.data.isNullOrBlank()) return
 
         pollerJob?.cancel()
         pollerJob = serviceScope.launch {

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/MainActivity.kt
@@ -167,7 +167,7 @@ class MainActivity : FlutterActivity() {
                         val reloadIntent = Intent(this, ForegroundService::class.java).apply {
                             action = ForegroundService.ACTION_RELOAD_CONTROL_BOT
                         }
-                        ContextCompat.startForegroundService(this, reloadIntent)
+                        startService(reloadIntent)
                         result.success(null)
                     }
 

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/MainActivity.kt
@@ -161,6 +161,15 @@ class MainActivity : FlutterActivity() {
                         WorkManager.getInstance(applicationContext).cancelAllWork()
                         result.success(null)
                     }
+                    "updateControlBot" -> {
+                        // Signal ForegroundService to reload its polling config.
+                        // DB settings are already saved by the Dart side before this call.
+                        val reloadIntent = Intent(this, ForegroundService::class.java).apply {
+                            action = ForegroundService.ACTION_RELOAD_CONTROL_BOT
+                        }
+                        ContextCompat.startForegroundService(this, reloadIntent)
+                        result.success(null)
+                    }
 
                     else -> result.notImplemented()
                 }

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/SmsOutSender.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/SmsOutSender.kt
@@ -1,0 +1,63 @@
+// Copyright (c) 2025-2026 Pavel D. (teslor)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.teslor.sms_telebot
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.telephony.SmsManager
+import android.util.Log
+import androidx.core.content.ContextCompat
+
+object SmsOutSender {
+
+    private const val TAG = "SmsOutSender"
+
+    sealed class SmsOutResult {
+        object Success : SmsOutResult()
+        data class Failure(val reason: String) : SmsOutResult()
+    }
+
+    fun send(context: Context, number: String, text: String): SmsOutResult {
+        // Validate number
+        val cleaned = number.replace(Regex("[\\s\\-()]+"), "")
+        if (!isValidNumber(cleaned)) {
+            return SmsOutResult.Failure("invalid_number")
+        }
+
+        // Check permission
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.SEND_SMS)
+            != PackageManager.PERMISSION_GRANTED) {
+            return SmsOutResult.Failure("no_permission")
+        }
+
+        return try {
+            val smsManager: SmsManager = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                context.getSystemService(SmsManager::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                SmsManager.getDefault()
+            }
+
+            val parts = smsManager.divideMessage(text)
+            if (parts.size == 1) {
+                smsManager.sendTextMessage(cleaned, null, text, null, null)
+            } else {
+                smsManager.sendMultipartTextMessage(cleaned, null, parts, null, null)
+            }
+
+            Log.i(TAG, "SMS sent to $cleaned (${parts.size} part(s))")
+            SmsOutResult.Success
+        } catch (e: Exception) {
+            Log.e(TAG, "SMS send failed: ${e.message}", e)
+            SmsOutResult.Failure("send_error: ${e.message}")
+        }
+    }
+
+    private fun isValidNumber(number: String): Boolean {
+        if (number.length < 7 || number.length > 15) return false
+        return number.matches(Regex("[+]?[0-9]+"))
+    }
+}

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/SmsTelebotApp.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/SmsTelebotApp.kt
@@ -39,7 +39,10 @@ class SmsTelebotApp : Application() {
 
     private fun startForegroundServiceIfNeeded() {
         val dbManager = DbManager.getInstance(this)
-        if (dbManager.getBoolSetting("isRunning") || dbManager.getBoolSetting("controlBotEnabled")) {
+        val isRunning = dbManager.getBoolSetting("isRunning")
+        val enableForeground = dbManager.getBoolSetting("enableForeground")
+        val controlBotEnabled = dbManager.getBoolSetting("controlBotEnabled")
+        if ((isRunning && enableForeground) || controlBotEnabled) {
             ContextCompat.startForegroundService(
                 this, Intent(this, ForegroundService::class.java)
             )

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/SmsTelebotApp.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/SmsTelebotApp.kt
@@ -9,7 +9,8 @@ import android.content.IntentFilter
 import androidx.core.content.ContextCompat
 
 /**
- * Application class that registers the device status receiver.
+ * Application class that registers the device status receiver
+ * and starts ForegroundService if control bot is configured.
  */
 class SmsTelebotApp : Application() {
 
@@ -18,6 +19,7 @@ class SmsTelebotApp : Application() {
     override fun onCreate() {
         super.onCreate()
         registerDeviceStatusReceiver()
+        startForegroundServiceIfNeeded()
     }
 
     private fun registerDeviceStatusReceiver() {
@@ -33,5 +35,14 @@ class SmsTelebotApp : Application() {
             filter,
             ContextCompat.RECEIVER_NOT_EXPORTED
         )
+    }
+
+    private fun startForegroundServiceIfNeeded() {
+        val dbManager = DbManager.getInstance(this)
+        if (dbManager.getBoolSetting("controlBotEnabled")) {
+            ContextCompat.startForegroundService(
+                this, Intent(this, ForegroundService::class.java)
+            )
+        }
     }
 }

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/SmsTelebotApp.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/SmsTelebotApp.kt
@@ -39,7 +39,7 @@ class SmsTelebotApp : Application() {
 
     private fun startForegroundServiceIfNeeded() {
         val dbManager = DbManager.getInstance(this)
-        if (dbManager.getBoolSetting("controlBotEnabled")) {
+        if (dbManager.getBoolSetting("isRunning") || dbManager.getBoolSetting("controlBotEnabled")) {
             ContextCompat.startForegroundService(
                 this, Intent(this, ForegroundService::class.java)
             )

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/TelegramPoller.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/TelegramPoller.kt
@@ -1,0 +1,232 @@
+// Copyright (c) 2025-2026 Pavel D. (teslor)
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.teslor.sms_telebot
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+class TelegramPoller(
+    private val context: Context,
+    private val dbManager: DbManager,
+    private val secretStorage: SecureStorageManager
+) {
+    companion object {
+        private const val TAG = "TelegramPoller"
+        private const val POLL_TIMEOUT_S = 25
+        private const val RETRY_DELAY_MS = 5_000L
+        private const val WIZARD_TIMEOUT_MS = 5 * 60 * 1000L
+    }
+
+    private enum class WizardStep { AWAITING_NUMBER, AWAITING_TEXT }
+
+    private data class WizardSession(
+        val step: WizardStep,
+        val number: String? = null,
+        val startedAt: Long = System.currentTimeMillis()
+    )
+
+    private val wizardSessions = mutableMapOf<Long, WizardSession>()
+
+    private val httpClient = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout((POLL_TIMEOUT_S + 10).toLong(), TimeUnit.SECONDS)
+        .writeTimeout(15, TimeUnit.SECONDS)
+        .build()
+
+    suspend fun run() = coroutineScope {
+        val secretResult = secretStorage.readSecret("control_bot")
+        if (!secretResult.isSuccess || secretResult.data.isNullOrBlank()) {
+            Log.w(TAG, "No control bot token configured")
+            return@coroutineScope
+        }
+        val token = secretResult.data!!
+        val chatId = dbManager.getSetting("controlBotChatId") ?: run {
+            Log.w(TAG, "No control bot chatId configured")
+            return@coroutineScope
+        }
+        val apiUrl = dbManager.getSetting("controlBotApiUrl")
+            .let { if (it.isNullOrBlank()) "https://api.telegram.org" else it }
+
+        var offset = dbManager.getSetting("controlBotUpdateOffset")?.toLongOrNull() ?: 0L
+        Log.i(TAG, "Polling started from offset $offset")
+
+        while (isActive) {
+            try {
+                val updates = fetchUpdates(token, chatId, apiUrl, offset)
+                for (update in updates) {
+                    val updateId = update.getLong("update_id")
+                    val message = update.optJSONObject("message") ?: continue
+                    val msgChatId = message.optJSONObject("chat")?.optLong("id") ?: continue
+                    if (msgChatId.toString() != chatId) continue  // security: ignore other chats
+                    processMessage(token, chatId, apiUrl, msgChatId, message)
+                    offset = updateId + 1
+                    dbManager.saveSetting("controlBotUpdateOffset", offset.toString())
+                }
+            } catch (e: CancellationException) {
+                Log.i(TAG, "Polling cancelled")
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "Poll error: ${e.message}")
+                delay(RETRY_DELAY_MS)
+            }
+        }
+    }
+
+    private fun fetchUpdates(token: String, chatId: String, apiUrl: String, offset: Long): List<JSONObject> {
+        val url = "$apiUrl/bot$token/getUpdates?timeout=$POLL_TIMEOUT_S&offset=$offset"
+        val request = Request.Builder().url(url).build()
+        return httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                if (response.code == 401 || response.code == 403) {
+                    throw CancellationException("Auth error ${response.code}")
+                }
+                return@use emptyList()
+            }
+            val body = response.body?.string() ?: return@use emptyList()
+            val json = JSONObject(body)
+            if (!json.optBoolean("ok")) return@use emptyList()
+            val result = json.optJSONArray("result") ?: return@use emptyList()
+            List(result.length()) { i -> result.getJSONObject(i) }
+        }
+    }
+
+    private fun processMessage(
+        token: String, chatId: String, apiUrl: String,
+        msgChatId: Long, message: JSONObject
+    ) {
+        val text = message.optString("text", "").trim()
+        val now = System.currentTimeMillis()
+
+        // Check wizard session timeout for this chat
+        val session = wizardSessions[msgChatId]
+        if (session != null && now - session.startedAt > WIZARD_TIMEOUT_MS) {
+            wizardSessions.remove(msgChatId)
+            sendMessage(token, chatId, apiUrl, "⏱ Session timed out. Send /send to start again.")
+            return
+        }
+
+        // Wizard in progress — consume message as wizard step
+        if (session != null) {
+            handleWizardStep(token, chatId, apiUrl, msgChatId, session, text)
+            return
+        }
+
+        // /send <number> <text>
+        if (text.startsWith("/send ")) {
+            val args = text.removePrefix("/send ").trim()
+            val spaceIdx = args.indexOf(' ')
+            if (spaceIdx == -1) {
+                sendMessage(token, chatId, apiUrl, "❌ Usage: /send <number> <message>")
+                return
+            }
+            val number = args.substring(0, spaceIdx).trim()
+            val smsText = args.substring(spaceIdx + 1).trim()
+            sendSmsAndConfirm(token, chatId, apiUrl, number, smsText)
+            return
+        }
+
+        // /send alone — start wizard
+        if (text == "/send") {
+            wizardSessions[msgChatId] = WizardSession(step = WizardStep.AWAITING_NUMBER)
+            sendMessage(token, chatId, apiUrl, "📱 Enter the recipient's phone number:")
+            return
+        }
+
+        // Reply to forwarded message
+        val replyTo = message.optJSONObject("reply_to_message")
+        if (replyTo != null) {
+            val parentText = replyTo.optString("text", "")
+            val number = extractPhoneNumber(parentText)
+            if (number == null) {
+                sendMessage(token, chatId, apiUrl,
+                    "❌ Could not extract a phone number from that message.")
+                return
+            }
+            sendSmsAndConfirm(token, chatId, apiUrl, number, text)
+            return
+        }
+
+        // Unknown command — show help
+        if (text.startsWith("/")) {
+            sendMessage(token, chatId, apiUrl,
+                "ℹ️ Commands:\n/send <number> <text> — send an SMS\nor reply to a forwarded SMS message.")
+        }
+    }
+
+    private fun handleWizardStep(
+        token: String, chatId: String, apiUrl: String,
+        msgChatId: Long, session: WizardSession, text: String
+    ) {
+        when (session.step) {
+            WizardStep.AWAITING_NUMBER -> {
+                if (text == "/send") {
+                    // Restart wizard
+                    wizardSessions[msgChatId] = WizardSession(step = WizardStep.AWAITING_NUMBER)
+                    sendMessage(token, chatId, apiUrl, "🔄 Started over. Enter recipient number:")
+                    return
+                }
+                wizardSessions[msgChatId] = WizardSession(
+                    step = WizardStep.AWAITING_TEXT,
+                    number = text
+                )
+                sendMessage(token, chatId, apiUrl, "✉️ Enter your message:")
+            }
+            WizardStep.AWAITING_TEXT -> {
+                val number = session.number ?: return
+                wizardSessions.remove(msgChatId)
+                sendSmsAndConfirm(token, chatId, apiUrl, number, text)
+            }
+        }
+    }
+
+    private fun extractPhoneNumber(text: String): String? {
+        val firstLine = text.lines().firstOrNull() ?: return null
+        val match = Regex("^[💬📞]\\s+([+\\d\\-()]+)\\s+🕒").find(firstLine)
+        return match?.groupValues?.getOrNull(1)?.trim()
+    }
+
+    private fun sendSmsAndConfirm(
+        token: String, chatId: String, apiUrl: String,
+        number: String, smsText: String
+    ) {
+        val reply = when (val result = SmsOutSender.send(context, number, smsText)) {
+            is SmsOutSender.SmsOutResult.Success ->
+                "✅ SMS sent to $number"
+            is SmsOutSender.SmsOutResult.Failure -> when {
+                result.reason == "invalid_number" ->
+                    "❌ Invalid number: \"$number\". Use format: +1234567890"
+                result.reason == "no_permission" ->
+                    "❌ SMS send permission not granted. Open the app to allow it."
+                else ->
+                    "❌ Failed to send SMS: ${result.reason.removePrefix("send_error: ")}"
+            }
+        }
+        sendMessage(token, chatId, apiUrl, reply)
+    }
+
+    private fun sendMessage(token: String, chatId: String, apiUrl: String, text: String) {
+        try {
+            val body = FormBody.Builder()
+                .add("chat_id", chatId)
+                .add("text", text)
+                .build()
+            val request = Request.Builder()
+                .url("$apiUrl/bot$token/sendMessage")
+                .post(body)
+                .build()
+            httpClient.newCall(request).execute().close()
+        } catch (e: Exception) {
+            Log.e(TAG, "sendMessage failed: ${e.message}")
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/teslor/sms_telebot/TelegramPoller.kt
+++ b/android/app/src/main/kotlin/com/teslor/sms_telebot/TelegramPoller.kt
@@ -65,12 +65,12 @@ class TelegramPoller(
                 val updates = fetchUpdates(token, chatId, apiUrl, offset)
                 for (update in updates) {
                     val updateId = update.getLong("update_id")
+                    offset = updateId + 1
+                    dbManager.saveSetting("controlBotUpdateOffset", offset.toString())
                     val message = update.optJSONObject("message") ?: continue
                     val msgChatId = message.optJSONObject("chat")?.optLong("id") ?: continue
                     if (msgChatId.toString() != chatId) continue  // security: ignore other chats
                     processMessage(token, chatId, apiUrl, msgChatId, message)
-                    offset = updateId + 1
-                    dbManager.saveSetting("controlBotUpdateOffset", offset.toString())
                 }
             } catch (e: CancellationException) {
                 Log.i(TAG, "Polling cancelled")

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -3,4 +3,9 @@ class AppConst {
   static const String appVersion = '0.7.2';
   static const String mainChannel = 'sms_telebot/main';
   static const filterKeys = ['whitelistSenders', 'whitelistBody', 'blacklistSenders', 'blacklistBody'];
+
+  // Control bot settings keys
+  static const String controlBotEnabled = 'controlBotEnabled';
+  static const String controlBotChatId = 'controlBotChatId';
+  static const String controlBotApiUrl = 'controlBotApiUrl';
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -111,5 +111,9 @@
   "error_unexpectedError": "Ein unerwarteter Fehler ist aufgetreten. Bitte später versuchen.",
   "error_secretsError": "Kein Zugriff auf den sicheren Speicher. Versuchen Sie es erneut. Wenn der Fehler bestehen bleibt, starten Sie die App neu und prüfen Sie Passwörter/Tokens in den Weiterleitungsregeln.",
   "warn_secretsRecovered": "Der sichere Speicher wurde nach einem Absturz wiederhergestellt. Gespeicherte Passwörter/Tokens wurden möglicherweise gelöscht. Prüfen Sie die Weiterleitungsregeln und geben Sie die Daten erneut ein.",
-  "warn_permissionsRequired": "Um mit der Überwachung zu beginnen, erteilen Sie bitte die erforderlichen Berechtigungen."
+  "warn_permissionsRequired": "Um mit der Überwachung zu beginnen, erteilen Sie bitte die erforderlichen Berechtigungen.",
+  "twoWay": "Two-way SMS",
+  "twoWay_help": "Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.",
+  "twoWay_enable": "Enable two-way SMS",
+  "twoWay_permissionWarning": "SMS send permission required. Open the app and grant it."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -111,5 +111,9 @@
   "error_unexpectedError": "An unexpected error occurred. Please try again later.",
   "error_secretsError": "Unable to access secure storage. Try again. If the error persists, restart the app and check passwords/tokens in the forwarding rules.",
   "warn_secretsRecovered": "Secure storage was recovered after a crash, saved passwords/tokens may have been deleted. Check the forwarding rules and enter the data again.",
-  "warn_permissionsRequired": "To start monitoring, please grant the required permissions."
+  "warn_permissionsRequired": "To start monitoring, please grant the required permissions.",
+  "twoWay": "Two-way SMS",
+  "twoWay_help": "Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.",
+  "twoWay_enable": "Enable two-way SMS",
+  "twoWay_permissionWarning": "SMS send permission required. Open the app and grant it."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -111,5 +111,9 @@
   "error_unexpectedError": "Ocurrió un error inesperado. Inténtelo más tarde.",
   "error_secretsError": "No se pudo acceder al almacenamiento seguro. Inténtelo de nuevo. Si el error persiste, reinicie la aplicación y verifique las contraseñas/tokens en las reglas de reenvío.",
   "warn_secretsRecovered": "El almacenamiento seguro se recuperó tras un fallo; es posible que se hayan eliminado las contraseñas/tokens guardados. Revise las reglas de reenvío y vuelva a introducir los datos.",
-  "warn_permissionsRequired": "Para iniciar el monitoreo, conceda los permisos necesarios."
+  "warn_permissionsRequired": "Para iniciar el monitoreo, conceda los permisos necesarios.",
+  "twoWay": "Two-way SMS",
+  "twoWay_help": "Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.",
+  "twoWay_enable": "Enable two-way SMS",
+  "twoWay_permissionWarning": "SMS send permission required. Open the app and grant it."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -111,5 +111,9 @@
   "error_unexpectedError": "Une erreur inattendue est survenue. Veuillez réessayer plus tard.",
   "error_secretsError": "Impossible d'accéder au stockage sécurisé. Réessayez. Si l'erreur persiste, redémarrez l'application et vérifiez les mots de passe/tokens dans les règles de transfert.",
   "warn_secretsRecovered": "Le stockage sécurisé a été restauré après un plantage ; les mots de passe/tokens enregistrés ont peut-être été supprimés. Vérifiez les règles de transfert et ressaisissez les données.",
-  "warn_permissionsRequired": "Pour démarrer la surveillance, veuillez accorder les autorisations requises."
+  "warn_permissionsRequired": "Pour démarrer la surveillance, veuillez accorder les autorisations requises.",
+  "twoWay": "Two-way SMS",
+  "twoWay_help": "Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.",
+  "twoWay_enable": "Enable two-way SMS",
+  "twoWay_permissionWarning": "SMS send permission required. Open the app and grant it."
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -111,5 +111,9 @@
   "error_unexpectedError": "एक अप्रत्याशित त्रुटि हुई। कृपया बाद में प्रयास करें।",
   "error_secretsError": "सुरक्षित स्टोरेज तक पहुंच नहीं हो सकी। फिर से प्रयास करें। यदि त्रुटि बनी रहती है, तो ऐप को पुनः शुरू करें और फ़ॉरवर्डिंग नियमों में पासवर्ड/टोकन जांचें।",
   "warn_secretsRecovered": "क्रैश के बाद सुरक्षित स्टोरेज पुनर्प्राप्त किया गया; सहेजे गए पासवर्ड/टोकन हटाए गए हो सकते हैं। फ़ॉरवर्डिंग नियम जांचें और डेटा फिर से दर्ज करें।",
-  "warn_permissionsRequired": "निगरानी शुरू करने के लिए, कृपया आवश्यक अनुमति दें।"
+  "warn_permissionsRequired": "निगरानी शुरू करने के लिए, कृपया आवश्यक अनुमति दें।",
+  "twoWay": "Two-way SMS",
+  "twoWay_help": "Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.",
+  "twoWay_enable": "Enable two-way SMS",
+  "twoWay_permissionWarning": "SMS send permission required. Open the app and grant it."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -111,5 +111,9 @@
   "error_unexpectedError": "予期しないエラーが発生しました。後でもう一度お試しください。",
   "error_secretsError": "安全なストレージにアクセスできません。再試行してください。問題が続く場合はアプリを再起動し、転送ルールのパスワード/トークンを確認してください。",
   "warn_secretsRecovered": "クラッシュ後に安全なストレージが復旧されました。保存済みのパスワード/トークンが削除された可能性があります。転送ルールを確認し、データを再入力してください。",
-  "warn_permissionsRequired": "監視を開始するには、必要な権限を許可してください。"
+  "warn_permissionsRequired": "監視を開始するには、必要な権限を許可してください。",
+  "twoWay": "Two-way SMS",
+  "twoWay_help": "Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.",
+  "twoWay_enable": "Enable two-way SMS",
+  "twoWay_permissionWarning": "SMS send permission required. Open the app and grant it."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -111,5 +111,9 @@
   "error_unexpectedError": "Ocorreu um erro inesperado. Tente novamente mais tarde.",
   "error_secretsError": "Não foi possível acessar o armazenamento seguro. Tente novamente. Se o erro persistir, reinicie o app e verifique as senhas/tokens nas regras de encaminhamento.",
   "warn_secretsRecovered": "O armazenamento seguro foi recuperado após uma falha; senhas/tokens salvos podem ter sido apagados. Verifique as regras de encaminhamento e insira os dados novamente.",
-  "warn_permissionsRequired": "Para iniciar o monitoramento, conceda as permissões necessárias."
+  "warn_permissionsRequired": "Para iniciar o monitoramento, conceda as permissões necessárias.",
+  "twoWay": "Two-way SMS",
+  "twoWay_help": "Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.",
+  "twoWay_enable": "Enable two-way SMS",
+  "twoWay_permissionWarning": "SMS send permission required. Open the app and grant it."
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -111,5 +111,9 @@
   "error_unexpectedError": "Произошла непредвиденная ошибка. Пожалуйста, попробуйте позже.",
   "error_secretsError": "Не удалось получить доступ к защищённому хранилищу. Попробуйте ещё раз. Если ошибка повторяется, перезапустите приложение и проверьте пароли/токены в правилах.",
   "warn_secretsRecovered": "Защищённое хранилище было восстановлено после сбоя, сохранённые пароли/токены могли быть удалены. Проверьте правила пересылки и введите данные заново.",
-  "warn_permissionsRequired": "Чтобы начать мониторинг, пожалуйста, предоставьте необходимые разрешения."
+  "warn_permissionsRequired": "Чтобы начать мониторинг, пожалуйста, предоставьте необходимые разрешения.",
+  "twoWay": "Two-way SMS",
+  "twoWay_help": "Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.",
+  "twoWay_enable": "Enable two-way SMS",
+  "twoWay_permissionWarning": "SMS send permission required. Open the app and grant it."
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -111,5 +111,9 @@
   "error_unexpectedError": "发生了意外错误。请稍后再试。",
   "error_secretsError": "无法访问安全存储。请重试。如果问题仍然存在，请重启应用，并检查转发规则中的密码/令牌。",
   "warn_secretsRecovered": "崩溃后安全存储已恢复，已保存的密码/令牌可能已被删除。请检查转发规则并重新输入数据。",
-  "warn_permissionsRequired": "要开始监控，请授予所需权限。"
+  "warn_permissionsRequired": "要开始监控，请授予所需权限。",
+  "twoWay": "Two-way SMS",
+  "twoWay_help": "Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.",
+  "twoWay_enable": "Enable two-way SMS",
+  "twoWay_permissionWarning": "SMS send permission required. Open the app and grant it."
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -783,6 +783,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'To start monitoring, please grant the required permissions.'**
   String get warn_permissionsRequired;
+
+  /// No description provided for @twoWay.
+  ///
+  /// In en, this message translates to:
+  /// **'Two-way SMS'**
+  String get twoWay;
+
+  /// No description provided for @twoWay_help.
+  ///
+  /// In en, this message translates to:
+  /// **'Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.'**
+  String get twoWay_help;
+
+  /// No description provided for @twoWay_enable.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable two-way SMS'**
+  String get twoWay_enable;
+
+  /// No description provided for @twoWay_permissionWarning.
+  ///
+  /// In en, this message translates to:
+  /// **'SMS send permission required. Open the app and grant it.'**
+  String get twoWay_permissionWarning;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -386,4 +386,18 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get warn_permissionsRequired =>
       'Um mit der Überwachung zu beginnen, erteilen Sie bitte die erforderlichen Berechtigungen.';
+
+  @override
+  String get twoWay => 'Two-way SMS';
+
+  @override
+  String get twoWay_help =>
+      'Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.';
+
+  @override
+  String get twoWay_enable => 'Enable two-way SMS';
+
+  @override
+  String get twoWay_permissionWarning =>
+      'SMS send permission required. Open the app and grant it.';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -383,4 +383,18 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get warn_permissionsRequired =>
       'To start monitoring, please grant the required permissions.';
+
+  @override
+  String get twoWay => 'Two-way SMS';
+
+  @override
+  String get twoWay_help =>
+      'Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.';
+
+  @override
+  String get twoWay_enable => 'Enable two-way SMS';
+
+  @override
+  String get twoWay_permissionWarning =>
+      'SMS send permission required. Open the app and grant it.';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -384,4 +384,18 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get warn_permissionsRequired =>
       'Para iniciar el monitoreo, conceda los permisos necesarios.';
+
+  @override
+  String get twoWay => 'Two-way SMS';
+
+  @override
+  String get twoWay_help =>
+      'Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.';
+
+  @override
+  String get twoWay_enable => 'Enable two-way SMS';
+
+  @override
+  String get twoWay_permissionWarning =>
+      'SMS send permission required. Open the app and grant it.';
 }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -387,4 +387,18 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get warn_permissionsRequired =>
       'Pour démarrer la surveillance, veuillez accorder les autorisations requises.';
+
+  @override
+  String get twoWay => 'Two-way SMS';
+
+  @override
+  String get twoWay_help =>
+      'Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.';
+
+  @override
+  String get twoWay_enable => 'Enable two-way SMS';
+
+  @override
+  String get twoWay_permissionWarning =>
+      'SMS send permission required. Open the app and grant it.';
 }

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -384,4 +384,18 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get warn_permissionsRequired =>
       'निगरानी शुरू करने के लिए, कृपया आवश्यक अनुमति दें।';
+
+  @override
+  String get twoWay => 'Two-way SMS';
+
+  @override
+  String get twoWay_help =>
+      'Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.';
+
+  @override
+  String get twoWay_enable => 'Enable two-way SMS';
+
+  @override
+  String get twoWay_permissionWarning =>
+      'SMS send permission required. Open the app and grant it.';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -368,4 +368,18 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get warn_permissionsRequired => '監視を開始するには、必要な権限を許可してください。';
+
+  @override
+  String get twoWay => 'Two-way SMS';
+
+  @override
+  String get twoWay_help =>
+      'Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.';
+
+  @override
+  String get twoWay_enable => 'Enable two-way SMS';
+
+  @override
+  String get twoWay_permissionWarning =>
+      'SMS send permission required. Open the app and grant it.';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -383,4 +383,18 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get warn_permissionsRequired =>
       'Para iniciar o monitoramento, conceda as permissões necessárias.';
+
+  @override
+  String get twoWay => 'Two-way SMS';
+
+  @override
+  String get twoWay_help =>
+      'Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.';
+
+  @override
+  String get twoWay_enable => 'Enable two-way SMS';
+
+  @override
+  String get twoWay_permissionWarning =>
+      'SMS send permission required. Open the app and grant it.';
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -384,4 +384,18 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get warn_permissionsRequired =>
       'Чтобы начать мониторинг, пожалуйста, предоставьте необходимые разрешения.';
+
+  @override
+  String get twoWay => 'Two-way SMS';
+
+  @override
+  String get twoWay_help =>
+      'Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.';
+
+  @override
+  String get twoWay_enable => 'Enable two-way SMS';
+
+  @override
+  String get twoWay_permissionWarning =>
+      'SMS send permission required. Open the app and grant it.';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -355,4 +355,18 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get warn_permissionsRequired => '要开始监控，请授予所需权限。';
+
+  @override
+  String get twoWay => 'Two-way SMS';
+
+  @override
+  String get twoWay_help =>
+      'Reply to forwarded messages or use /send <number> <text> in the configured bot to send SMS from this device.';
+
+  @override
+  String get twoWay_enable => 'Enable two-way SMS';
+
+  @override
+  String get twoWay_permissionWarning =>
+      'SMS send permission required. Open the app and grant it.';
 }

--- a/lib/pages/control_bot_settings.dart
+++ b/lib/pages/control_bot_settings.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../l10n/generated/app_localizations.dart';
+import '../state.dart';
+import '../service.dart';
+
+class ControlBotSection extends StatefulWidget {
+  const ControlBotSection({super.key});
+
+  @override
+  State<ControlBotSection> createState() => _ControlBotSectionState();
+}
+
+class _ControlBotSectionState extends State<ControlBotSection> {
+  late TextEditingController _tokenController;
+  late TextEditingController _apiUrlController;
+  late TextEditingController _chatIdController;
+
+  bool _enabled = false;
+  bool _isChanged = false;
+  bool? _saveResult;
+  String? _testResult;
+  bool _isTesting = false;
+  bool _hasSmsPermission = true;
+
+  @override
+  void initState() {
+    super.initState();
+    final appState = context.read<AppState>();
+    _enabled = appState.controlBotEnabled;
+    _tokenController = TextEditingController(
+      text: (appState.controlBotConfig['token'] as String?) ?? '',
+    );
+    _apiUrlController = TextEditingController(
+      text: (appState.controlBotConfig['apiUrl'] as String?) ?? '',
+    );
+    _chatIdController = TextEditingController(
+      text: (appState.controlBotConfig['chatId'] as String?) ?? '',
+    );
+    _checkSmsPermission();
+  }
+
+  @override
+  void dispose() {
+    _tokenController.dispose();
+    _apiUrlController.dispose();
+    _chatIdController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _checkSmsPermission() async {
+    final granted = await getSmsPermission();
+    if (mounted) setState(() => _hasSmsPermission = granted);
+  }
+
+  void _onChanged() {
+    setState(() {
+      _saveResult = null;
+      _testResult = null;
+      _isChanged = true;
+    });
+  }
+
+  Future<void> _testConnection() async {
+    setState(() { _isTesting = true; _testResult = null; });
+    FocusManager.instance.primaryFocus?.unfocus();
+
+    final result = await getUpdates(
+      _tokenController.text.trim(),
+      _apiUrlController.text.trim(),
+    );
+
+    if (!mounted) return;
+    if (result.isSuccess && result.data != null) {
+      setState(() {
+        _chatIdController.text = result.data!;
+        _isTesting = false;
+        _testResult = 'ok';
+        _isChanged = true;
+      });
+    } else {
+      setState(() {
+        _isTesting = false;
+        _testResult = result.code;
+      });
+    }
+  }
+
+  Future<void> _save() async {
+    FocusManager.instance.primaryFocus?.unfocus();
+    final appState = context.read<AppState>();
+
+    // Request SEND_SMS permission when enabling
+    if (_enabled) {
+      final granted = await getSmsPermission(openSettings: true);
+      if (mounted) setState(() => _hasSmsPermission = granted);
+    }
+
+    final result = await appState.updateControlBot(
+      enabled: _enabled,
+      config: {
+        'token': _tokenController.text.trim(),
+        'chatId': _chatIdController.text.trim(),
+        'apiUrl': _apiUrlController.text.trim(),
+      },
+    );
+
+    if (mounted) {
+      setState(() {
+        _saveResult = result.isSuccess;
+        _isChanged = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+          child: Text(l10n.twoWay, style: theme.textTheme.titleSmall),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+          child: Text(l10n.twoWay_help,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              )),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: TextField(
+            controller: _tokenController,
+            onChanged: (_) => _onChanged(),
+            obscureText: true,
+            decoration: InputDecoration(
+              labelText: l10n.tbot_token,
+              border: const OutlineInputBorder(),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: TextField(
+            controller: _apiUrlController,
+            onChanged: (_) => _onChanged(),
+            decoration: InputDecoration(
+              labelText: l10n.tbot_apiUrl,
+              hintText: l10n.tbot_apiUrlInfo,
+              border: const OutlineInputBorder(),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: TextField(
+            controller: _chatIdController,
+            onChanged: (_) => _onChanged(),
+            decoration: InputDecoration(
+              labelText: l10n.tbot_chatId,
+              hintText: l10n.tbot_chatIdInfo,
+              border: const OutlineInputBorder(),
+            ),
+          ),
+        ),
+        if (_testResult != null && _testResult != 'ok')
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
+            child: Text(
+              getLocalizedError(l10n, _testResult!, 'telegram_bot'),
+              style: TextStyle(color: theme.colorScheme.error, fontSize: 12),
+            ),
+          ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              OutlinedButton(
+                onPressed: _isTesting ? null : _testConnection,
+                child: _isTesting
+                    ? const SizedBox(width: 16, height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2))
+                    : Text(l10n.action_test),
+              ),
+              const SizedBox(width: 12),
+              FilledButton(
+                onPressed: _isChanged ? _save : null,
+                child: Text(l10n.action_save),
+              ),
+              if (_saveResult == true) ...[
+                const SizedBox(width: 8),
+                Icon(Icons.check, color: theme.colorScheme.primary, size: 20),
+              ],
+            ],
+          ),
+        ),
+        SwitchListTile(
+          title: Text(l10n.twoWay_enable),
+          value: _enabled,
+          onChanged: (val) {
+            setState(() { _enabled = val; _isChanged = true; _saveResult = null; });
+          },
+          contentPadding: const EdgeInsets.fromLTRB(13, 0, 10, 0),
+        ),
+        if (_enabled && !_hasSmsPermission)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Text(
+              l10n.twoWay_permissionWarning,
+              style: TextStyle(color: theme.colorScheme.error, fontSize: 12),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/pages/control_bot_settings.dart
+++ b/lib/pages/control_bot_settings.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../state.dart';
@@ -49,8 +50,12 @@ class _ControlBotSectionState extends State<ControlBotSection> {
   }
 
   Future<void> _checkSmsPermission() async {
-    final granted = await getSmsPermission();
-    if (mounted) setState(() => _hasSmsPermission = granted);
+    final status = await Permission.sms.status;
+    if (mounted) {
+      setState(() {
+        _hasSmsPermission = status.isGranted;
+      });
+    }
   }
 
   void _onChanged() {

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -5,6 +5,7 @@ import '../styles.dart';
 import '../state.dart';
 import '../service.dart';
 import '../widgets/action_button.dart';
+import 'control_bot_settings.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -182,6 +183,8 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
             onChanged: (String value) => _onSettingChanged(),
           ),
+          const Divider(),
+          const ControlBotSection(),
         ],
       ),
 

--- a/lib/service.dart
+++ b/lib/service.dart
@@ -247,3 +247,9 @@ void stopWorkersNative() {
     _mainChannel.invokeMethod<void>('stopWorkers').catchError((_, _) {}),
   );
 }
+
+Future<void> updateControlBotNative() async {
+  try {
+    await _mainChannel.invokeMethod<void>('updateControlBot');
+  } catch (_) {}
+}

--- a/lib/state.dart
+++ b/lib/state.dart
@@ -113,7 +113,8 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
     _stopStatsPolling();
     await MainDb.instance.saveBoolSetting('isRunning', false);
     stopWorkersNative();
-    stopForegroundServiceNative();
+    // Only stop the service if control bot isn't keeping it alive
+    if (!controlBotEnabled) stopForegroundServiceNative();
   }
 
   @override

--- a/lib/state.dart
+++ b/lib/state.dart
@@ -346,28 +346,32 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   Future<CallResult> updateControlBot({
-    required bool enabled,
-    required Map<String, dynamic> config,
+    bool? enabled,
+    Map<String, dynamic>? config,
   }) async {
-    final token = (config['token'] as String?) ?? '';
-    final chatId = (config['chatId'] as String?) ?? '';
-    final apiUrl = (config['apiUrl'] as String?) ?? '';
+    final resolvedEnabled = enabled ?? controlBotEnabled;
+    final resolvedConfig = config ?? controlBotConfig;
+    final token = (resolvedConfig['token'] as String?) ?? '';
+    final chatId = (resolvedConfig['chatId'] as String?) ?? '';
+    final apiUrl = (resolvedConfig['apiUrl'] as String?) ?? '';
 
-    // Save token to secure storage
+    // Save or delete token in secure storage
     if (token.isNotEmpty) {
       final secretResult = await saveSecretNative('control_bot', token);
       if (!secretResult.isSuccess) return secretResult;
+    } else {
+      await deleteSecretNative('control_bot');
     }
 
     // Save other settings to DB
     await MainDb.instance.saveSettings({
-      AppConst.controlBotEnabled: enabled ? '1' : '0',
+      AppConst.controlBotEnabled: resolvedEnabled ? '1' : '0',
       AppConst.controlBotChatId: chatId,
       AppConst.controlBotApiUrl: apiUrl,
     });
 
-    controlBotEnabled = enabled;
-    controlBotConfig = config;
+    controlBotEnabled = resolvedEnabled;
+    controlBotConfig = resolvedConfig;
     notifyListeners();
 
     // Signal native side to restart poller with new config

--- a/lib/state.dart
+++ b/lib/state.dart
@@ -22,6 +22,10 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
   bool enableForeground = false;
   String deviceLabel = '';
 
+  // Control bot (two-way SMS)
+  bool controlBotEnabled = false;
+  Map<String, dynamic> controlBotConfig = {};
+
   // Rule list
   List<Map<String, dynamic>> rules = [];
   Map<String, dynamic>? selectedRule;
@@ -74,6 +78,9 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
     if (isRunning) {
       _startStatsPolling();
       if (enableForeground) await startForegroundServiceNative();
+    }
+    if (controlBotEnabled && !enableForeground) {
+      await startForegroundServiceNative();
     }
   }
 
@@ -133,6 +140,15 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
     notifyChargerState = settings['notifyChargerState'] == '1';
     enableForeground = settings['enableForeground'] == '1';
     deviceLabel = settings['deviceLabel'] ?? '';
+    controlBotEnabled = settings[AppConst.controlBotEnabled] == '1';
+    controlBotConfig = {
+      'chatId': settings[AppConst.controlBotChatId] ?? '',
+      'apiUrl': settings[AppConst.controlBotApiUrl] ?? '',
+    };
+    final tokenResult = await readSecretNative('control_bot');
+    if (tokenResult.isSuccess && tokenResult.data != null) {
+      controlBotConfig = {...controlBotConfig, 'token': tokenResult.data!};
+    }
     notifyListeners();
   }
 
@@ -326,6 +342,36 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
     this.deviceLabel = deviceLabel;
 
     notifyListeners();
+    return okResult();
+  }
+
+  Future<CallResult> updateControlBot({
+    required bool enabled,
+    required Map<String, dynamic> config,
+  }) async {
+    final token = (config['token'] as String?) ?? '';
+    final chatId = (config['chatId'] as String?) ?? '';
+    final apiUrl = (config['apiUrl'] as String?) ?? '';
+
+    // Save token to secure storage
+    if (token.isNotEmpty) {
+      final secretResult = await saveSecretNative('control_bot', token);
+      if (!secretResult.isSuccess) return secretResult;
+    }
+
+    // Save other settings to DB
+    await MainDb.instance.saveSettings({
+      AppConst.controlBotEnabled: enabled ? '1' : '0',
+      AppConst.controlBotChatId: chatId,
+      AppConst.controlBotApiUrl: apiUrl,
+    });
+
+    controlBotEnabled = enabled;
+    controlBotConfig = config;
+    notifyListeners();
+
+    // Signal native side to restart poller with new config
+    await updateControlBotNative();
     return okResult();
   }
 


### PR DESCRIPTION

## Summary

- Adds a global Telegram control bot that lets users send outgoing SMS directly from Telegram, independent of the existing forwarding toggle
- Supports three send modes: reply-to-forwarded-SMS (auto-extracts phone number), `/send <number> <text>` one-liner, and interactive `/send` wizard with 5-minute timeout
- New "Two-way SMS" settings section: configure bot token, API URL, chat ID (auto-fetched via Test Connection), and enable/disable toggle with SEND_SMS permission flow

## Architecture

**New Kotlin components:**
- `SmsOutSender.kt` — wraps SmsManager for outgoing SMS (API 31+ aware, multipart support, runtime permission check)
- `TelegramPoller.kt` — long-polls Telegram getUpdates (25s timeout) in a coroutine; wizard state machine, chatId security filter, 401/403 cancellation, offset persistence

**Modified Kotlin components:**
- `ForegroundService.kt` — coroutine scope + TelegramPoller lifecycle; ACTION_RELOAD_CONTROL_BOT for hot config reload without service restart
- `SmsTelebotApp.kt` / `BootReceiver.kt` — start condition: `(isRunning && enableForeground) || controlBotEnabled`
- `MainActivity.kt` — new updateControlBot MethodChannel handler

**Dart layer:**
- `AppState.updateControlBot()` — persists config to DB + Keystore, signals native via MethodChannel
- `ControlBotSection` widget in `lib/pages/control_bot_settings.dart`
- 4 new localization keys across all 9 languages

## Test plan

- [ ] Configure bot token + chat ID via Test Connection → Save → verify poller starts (logcat "TelegramPoller started")
- [ ] Reply to a forwarded SMS in Telegram → verify SMS sent to original number
- [ ] Send `/send +1234567890 Hello` → verify SMS delivered
- [ ] Send `/send` → complete wizard (number prompt → text prompt → confirm)
- [ ] Toggle forwarding off while control bot enabled → verify service stays alive
- [ ] Disable control bot while forwarding is off → verify service stops
- [ ] Reboot with `controlBotEnabled=true` → verify poller resumes
- [ ] Send from unauthorized chat → verify silently ignored
- [ ] Revoke SEND_SMS permission → verify bot replies with no-permission error
- [ ] Hot-reload: change token/chatId and Save → verify poller restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

The worktree at .claude/worktrees/feat+telegram-two-way-sms is preserved so you can iterate on any PR feedback.